### PR TITLE
add lightening talks

### DIFF
--- a/content/cfposters/banner.md
+++ b/content/cfposters/banner.md
@@ -24,7 +24,7 @@ advanced:
   css_class: 
 ---
 
-The ACM Conference on Reproducibility and Replicability is open for poster submissions. Each submission will consist of a 2-page extended abstract, including all content, following the ACM standard conference template. These 2-page abstracts will be reviewed for applicability and downselected for quality based on available poster space.
+The ACM Conference on Reproducibility and Replicability is open for poster submissions. Each submission will consist of a 2-page extended abstract, including all content, following the ACM standard conference template. These 2-page abstracts will be reviewed for applicability and downselected for quality based on available poster space. More details [here](#submissions).
 
 {{< cta cta_text="Submit -->" cta_link="https://easychair.org/conferences/?conf=acmrep24" cta_new_tab="false" >}}
 

--- a/content/cfposters/submissions.md
+++ b/content/cfposters/submissions.md
@@ -11,6 +11,10 @@ To submit a 2-page extended abstract for a poster, please use [EasyChair submiss
 
 Posters selected for presentation at the conference must fit within an A0 portrait size.  
 
+{{% callout info %}}
+Authors of accepted poster submissions are expected to give a short talk about their poster in a lightening talk session. Of these authors only those who attend in person will get poster space. Of those who are not able to attend in person will not be given poster space but will still be able to present a remote/prerecorded lightening talk.
+{{% /callout %}} 
+
 {{< cta cta_text="Submit -->" cta_link="https://easychair.org/conferences/?conf=acmrep24" cta_new_tab="false" >}}
 
 For questions, please contact Jay Lofstead ([gflofst@sandia.gov](mailto:gflofst@sandia.gov)).  


### PR DESCRIPTION
Banner now has a link to submission details which now include a callout about lightening talks. Don't worry about the broken call-to-action button. It's due to a configuration issue of the preview build. It works in the final build.