### PR TITLE
Splitting local arrangements into chairs and team

### DIFF
--- a/content/home/organizers.md
+++ b/content/home/organizers.md
@@ -24,12 +24,15 @@ Victoria Stodden (University of Southern California)
 Reed Milewicz  (Sandia National Laboratories)  
 Line Pouchard (Brookhaven National Laboratory)  
 
-### Local Arrangements
+### Local Arrangements Chairs
 Arnaud Legrand (CNRS)  
 Camille Maumet (Inria)  
+
+### Local Arrangements Team
 Matthieu Simonin (Inria)  
 Anne-Cécile Orgerie (CNRS)  
 Edith Blin (Inria)  
+Armelle Mozziconacci (CNRS)
 
 ### Proceedings
 Philippe Bonnet (University of Copenhagen)  


### PR DESCRIPTION
This PR modify the list of members in the local arrangement into chairs and team.