### PR TITLE
Update registration closing and early bird dates

### DIFF
--- a/content/cfp/deadlines.md
+++ b/content/cfp/deadlines.md
@@ -13,8 +13,8 @@ active: true
 <span style=color:grey>Notification of acceptance:  May 3, 2024</span>  
 <span style=color:blue;font-weight:bold>Registration open: mid-May</span>  
 <span style=color:blue;font-weight:bold>Camera-ready copy:  May 24, 2024</span>  
-<span style=color:blue;font-weight:bold>Early-bird registration close: May 31, 2024</span>  
-Registration close: June 8, 2024  
+<span style=color:blue;font-weight:bold>Early-bird registration close: <s>May 31</s> June 8, 2024</span>  
+Registration close: <s>June 8</s> June 20, 2024  
 Conference:  June 18-20, 2024  
 
 {{< cta cta_text="Submit -->" cta_link="https://easychair.org/conferences/?conf=acmrep24" cta_new_tab="false" >}}

--- a/content/cfposters/deadlines.md
+++ b/content/cfposters/deadlines.md
@@ -9,8 +9,8 @@ active: true
 <span style=color:grey>Poster submissions: May 3, 2024, 23:59 AOE</span>  
 <span style=color:grey>Notification of acceptance: May 10, 2024</span>  
 <span style=color:blue;font-weight:bold>Registration open: mid-May</span>  
-<span style=color:blue;font-weight:bold>Early-bird registration close: May 31, 2024</span>  
-Registration close: June 8, 2024  
+<span style=color:blue;font-weight:bold>Early-bird registration close: <s>May 31</s> June 8, 2024</span>  
+Registration close: <s>June 8</s> June 20, 2024  
 Conference:  June 18-20, 2024  
 
 

--- a/content/cft/deadlines.md
+++ b/content/cft/deadlines.md
@@ -9,8 +9,8 @@ active: true
 <span style=color:grey>Paper submission (Long and Short): ~~January 29~~ February ~~12~~ 16, 2024, 23:59 AOE</span>  
 <span style=color:grey>Notification of acceptance: May 3, 2024</span>  
 <span style=color:blue;font-weight:bold>Registration open: mid-May</span>  
-<span style=color:blue;font-weight:bold>Early-bird registration close: May 31, 2024</span>  
-Registration close: June 8, 2024  
+<span style=color:blue;font-weight:bold>Early-bird registration close: <s>May 31</s> June 8, 2024</span>  
+Registration close: <s>June 8</s> June 20, 2024  
 Conference:  June 18-20, 2024  
 
 

--- a/content/registration/index.md
+++ b/content/registration/index.md
@@ -3,7 +3,7 @@ title: "Registration"
 ---
 
 {{% callout note %}}
-Registrations will be online only and will close on June 8, 2024. **On-site registrations will not be available**.
+Registrations will be online only and will close on <s>June 8</s> June 20, 2024. **On-site registrations will not be available**.
 
 {{% /callout %}}
 {{% cta cta_text="Register" cta_link="https://web.cvent.com/event/213c1224-ee5a-4cff-aff0-ef4b0df0441c/summary" cta_new_tab="false" %}}
@@ -25,8 +25,8 @@ Virtual registration includes: online access to all sessions and selected tutori
 
 # Important Dates
 <span style=color:blue;font-weight:bold>Registration open: <s>early May</s> mid-May</span>  
-<span style=color:blue;font-weight:bold>Early-bird registration close: <s>May 19</s> May 31</span>  
-Registration close: June 8  
+<span style=color:blue;font-weight:bold>Early-bird registration close: <s>May 19</s> <s>May 31</s> June 8</span>  
+Registration close: <s>June 8</s> June 20
 Conference:  June 18-20, 2024  
 
 # Terms and conditions


### PR DESCRIPTION
Closes #75
This PR is concurrent with #72 

Changes the registration dates (early bird and closing) on the following pages:

- https://acm-rep.github.io/2024/registration/
- https://acm-rep.github.io/2024/cfp/
- https://acm-rep.github.io/2024/cft/
- https://acm-rep.github.io/2024/cfposters/
